### PR TITLE
Add tokenlon strategy

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -37,7 +37,7 @@
         "strategies": {
           "type": "array",
           "minItems": 1,
-          "maxItems": 3,
+          "maxItems": 5,
           "items": {
             "type": "object",
             "properties": {

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -49,6 +49,7 @@ import { strategy as theGraphBalance } from './the-graph-balance';
 import { strategy as theGraphDelegation } from './the-graph-delegation';
 import { strategy as theGraphIndexing } from './the-graph-indexing';
 import { strategy as whitelist } from './whitelist';
+import { strategy as tokenlon } from './tokenlon';
 
 export default {
   balancer,
@@ -101,5 +102,9 @@ export default {
   'the-graph-balance': theGraphBalance,
   'the-graph-delegation': theGraphDelegation,
   'the-graph-indexing': theGraphIndexing,
+<<<<<<< HEAD
   whitelist
+=======
+  tokenlon
+>>>>>>> 00b716b (Add tokenlon strategy)
 };

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -48,6 +48,7 @@ import { strategy as opium } from './opium';
 import { strategy as theGraphBalance } from './the-graph-balance';
 import { strategy as theGraphDelegation } from './the-graph-delegation';
 import { strategy as theGraphIndexing } from './the-graph-indexing';
+import { strategy as whitelist } from './whitelist';
 
 export default {
   balancer,
@@ -99,5 +100,6 @@ export default {
   opium,
   'the-graph-balance': theGraphBalance,
   'the-graph-delegation': theGraphDelegation,
-  'the-graph-indexing': theGraphIndexing
+  'the-graph-indexing': theGraphIndexing,
+  whitelist
 };

--- a/src/strategies/masterchef/index.ts
+++ b/src/strategies/masterchef/index.ts
@@ -114,7 +114,7 @@ export async function strategy(
     masterchefParams
   );
 
-  const one_gwei = BigNumber.from(10).pow(9)
+  const one_gwei = BigNumber.from(10).pow(9);
   let stakedBalances = [];
   if (masterchefResult && masterchefResult.pools.length == 1) {
     stakedBalances = masterchefResult.pools[0].users.map((u) => {
@@ -134,7 +134,9 @@ export async function strategy(
     const token0perUni = pair.reserve0 / pair.totalSupply;
     const token1perUni = pair.reserve1 / pair.totalSupply;
     stakedBalances.forEach((u: any) => {
-      const userScore = u.amount / one_gwei.toNumber() * (pair.token0.id == tokenAddress ? token0perUni : token1perUni);
+      const userScore =
+        (u.amount / one_gwei.toNumber()) *
+        (pair.token0.id == tokenAddress ? token0perUni : token1perUni);
       const userScoreInEther = userScore / one_gwei.toNumber();
       const userAddress = getAddress(u.address);
       if (!score[userAddress]) score[userAddress] = 0;

--- a/src/strategies/pancake/index.ts
+++ b/src/strategies/pancake/index.ts
@@ -112,8 +112,7 @@ export async function strategy(
     Object.entries(score).map((address, index) => [
       address[0],
       address[1] +
-        parseFloat(formatUnits(masterBalances[index].amount.toString(), 18))
-        +
+        parseFloat(formatUnits(masterBalances[index].amount.toString(), 18)) +
         sousBalances.reduce(
           (prev: number, cur: any, idx: number) =>
             prev +

--- a/src/strategies/the-graph/baseStrategy.ts
+++ b/src/strategies/the-graph/baseStrategy.ts
@@ -1,3 +1,4 @@
+import { getAddress } from '@ethersproject/address';
 import { getTokenLockWallets } from './tokenLockWallets';
 import { balanceStrategy } from '../the-graph-balance/balances';
 import { indexersStrategy } from '../the-graph-indexing/indexers';
@@ -77,5 +78,10 @@ export async function baseStrategy(
     combinedScores[account] = accountScore;
   }
 
-  return combinedScores;
+  return Object.fromEntries(
+    Object.entries(combinedScores).map((score) => [
+      getAddress(score[0]),
+      score[1]
+    ])
+  );
 }

--- a/src/strategies/the-graph/tokenLockWallets.ts
+++ b/src/strategies/the-graph/tokenLockWallets.ts
@@ -37,7 +37,7 @@ export async function getTokenLockWallets(
   };
   if (snapshot !== 'latest') {
     // @ts-ignore
-    tokenLockParams.graphAccounts.__args.block = { number: snapshot };
+    tokenLockParams.tokenLockWallets.__args.block = { number: snapshot };
   }
   const result = await subgraphRequest(
     TOKEN_DISTRIBUTION_SUBGRAPH_URL[network],

--- a/src/strategies/tokenlon/examples.json
+++ b/src/strategies/tokenlon/examples.json
@@ -6,6 +6,8 @@
             "params": {
                 "uniswap": "0x7924a818013f39cf800f5589ff1f1f0def54f31f",
                 "sushiswap": "0x55d31f68975e446a40a2d02ffa4b0e1bfb233c2f",
+                "stakingRewardUniswap": "0x929CF614C917944dD278BC2134714EaA4121BC6A",
+                "stakingRewardSushiSwap": "0x11520d501E10E2E02A2715C4A9d3F8aEb1b72A7A",
                 "token": "0x0000000000095413afC295d19EDeb1Ad7B71c952",
                 "decimals": 18
             }

--- a/src/strategies/tokenlon/examples.json
+++ b/src/strategies/tokenlon/examples.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "Tokenlon",
+        "strategy": {
+            "name": "tokenlon",
+            "params": {
+                "uniswap": "0x7924a818013f39cf800f5589ff1f1f0def54f31f",
+                "sushiswap": "0x55d31f68975e446a40a2d02ffa4b0e1bfb233c2f",
+                "token": "0x0000000000095413afC295d19EDeb1Ad7B71c952",
+                "decimals": 18
+            }
+        },
+        "network": "1",
+        "addresses": [
+            "0x95bbf6bebb8caaa486ffab6faf76cf312a5abfd0",
+            "0x8f1D14f46a4a22DAA848E327FD7a30BfAE2D3d9c"
+        ],
+        "snapshot": 11905315
+    }
+]

--- a/src/strategies/tokenlon/index.ts
+++ b/src/strategies/tokenlon/index.ts
@@ -1,0 +1,117 @@
+import { formatUnits, parseUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'BenjaminLu';
+export const version = '0.1.0';
+
+const abi = [
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    [
+      [options.token, 'balanceOf', [options.uniswap]],
+      [options.uniswap, 'totalSupply'],
+      [options.token, 'balanceOf', [options.sushiswap]],
+      [options.sushiswap, 'totalSupply'],
+      ...addresses.map((address: any) => [
+        options.uniswap,
+        'balanceOf',
+        [address]
+      ]),
+      ...addresses.map((address: any) => [
+        options.sushiswap,
+        'balanceOf',
+        [address]
+      ]),
+      ...addresses.map((address: any) => [
+        options.token,
+        'balanceOf',
+        [address]
+      ])
+    ],
+    { blockTag }
+  );
+
+  const lonPerLPUniswap = parseUnits(response[0][0].toString(), 18).div(
+    response[1][0]
+  );
+  const lonPerLPSushiSwap = parseUnits(response[2][0].toString(), 18).div(
+    response[3][0]
+  );
+  const lpBalancesUniswap = response.slice(
+    4,
+    addresses.length + 4
+  );
+  const lpBalancesSushiSwap = response.slice(
+    addresses.length * 1 + 4,
+    addresses.length * 2 + 4
+  );
+  const tokenBalances = response.slice(
+    addresses.length * 2 + 4,
+    addresses.length * 3 + 4
+  );
+
+  return Object.fromEntries(
+    Array(addresses.length)
+      .fill('')
+      .map((_, i) => {
+        const lpBalanceUniswap = lpBalancesUniswap[i][0];
+        const lonLpBalanceUniswap = lpBalanceUniswap.mul(lonPerLPUniswap).div(parseUnits('1', 18));
+        const lpBalanceSushiSwap = lpBalancesSushiSwap[i][0];
+        const lonLpBalanceSushiSwap = lpBalanceSushiSwap.mul(lonPerLPSushiSwap).div(parseUnits('1', 18));
+
+        return [
+          addresses[i],
+          parseFloat(
+            formatUnits(
+              tokenBalances[i][0]
+                .add(lonLpBalanceUniswap)
+                .add(lonLpBalanceSushiSwap),
+              options.decimals
+            )
+          )
+        ];
+      })
+  );
+}

--- a/src/strategies/whitelist/examples.json
+++ b/src/strategies/whitelist/examples.json
@@ -4,6 +4,7 @@
     "strategy": {
       "name": "whitelist",
       "params": {
+        "symbol": "POINT",
         "addresses": [
           "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
           "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7"

--- a/src/strategies/whitelist/examples.json
+++ b/src/strategies/whitelist/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "whitelist",
+      "params": {
+        "addresses": [
+          "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+          "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7"
+        ]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/whitelist/index.ts
+++ b/src/strategies/whitelist/index.ts
@@ -1,0 +1,19 @@
+export const author = 'bonustrack';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const whitelist = options?.addresses.map((address) => address.toLowerCase());
+  return Object.fromEntries(
+    addresses.map((address) => [
+      address,
+      whitelist.includes(address.toLowerCase()) ? 1 : 0
+    ])
+  );
+}


### PR DESCRIPTION
Add tokenlon stratrgy

LON phase 2 liquidity mining:
https://tokenlon.zendesk.com/hc/en-us/articles/360055773831-Tutorial-of-the-2nd-phase-of-LON-liquidity-mining

Relative contracts:
[Uniswap LON-ETH pair](https://etherscan.io/address/0x7924a818013f39cf800f5589ff1f1f0def54f31f#readContract)
[SushiSwap LON-USDT](https://etherscan.io/address/0x55d31f68975e446a40a2d02ffa4b0e1bfb233c2f#readContract)
[Uniswap StakingRewards contract](https://etherscan.io/address/0x929CF614C917944dD278BC2134714EaA4121BC6A#readContract)
[SushiSwap StakingMultiRewards contract](https://etherscan.io/address/0x11520d501E10E2E02A2715C4A9d3F8aEb1b72A7A#readContract)

Strategy:
```
user's voting power = LON balance of user +  
    (users' LP token + users' LP token staked in Uniswap StakingRewards contract) / LP total supply * LON balance of ETH-LON Uniswap pool +
    (earned in StakingRewards contract)
    (users' SLP token + users' SLP token staked in SushiSwap StakingMultiRewards contract) / SLP total supply * LON balance of LON-USDT SushiSwap pool +
    (earned in StakingMultiRewards contract)
```


```
npm run test --strategy=tokenlon
```

Result:
```
Strategy: "tokenlon"
Tokenlon
[
  {
    '0x95bbf6bebb8caaa486ffab6faf76cf312a5abfd0': 309.4628240485401,
    '0x8f1D14f46a4a22DAA848E327FD7a30BfAE2D3d9c': 251.76912211322397
  }
]
getScores: 1.782s
```