### PR TITLE
Add tokenlon strategy

### DIFF
--- a/src/strategies/ens-domains-owned/index.ts
+++ b/src/strategies/ens-domains-owned/index.ts
@@ -1,3 +1,4 @@
+import { getAddress } from '@ethersproject/address';
 import { subgraphRequest } from '../../utils';
 
 const ENS_SUBGRAPH_URL = {
@@ -50,7 +51,7 @@ export async function strategy(
   if (result && result.domains) {
     result.domains.forEach((u) => {
       u.subdomains.forEach((domain) => {
-        const userAddress = domain.owner.id;
+        const userAddress = getAddress(domain.owner.id);
         if (!score[userAddress]) score[userAddress] = 0;
         score[userAddress] = score[userAddress] + 1;
       });

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -49,6 +49,7 @@ import { strategy as theGraphBalance } from './the-graph-balance';
 import { strategy as theGraphDelegation } from './the-graph-delegation';
 import { strategy as theGraphIndexing } from './the-graph-indexing';
 import { strategy as whitelist } from './whitelist';
+import { strategy as tokenlon } from './tokenlon';
 
 export default {
   balancer,
@@ -101,5 +102,9 @@ export default {
   'the-graph-balance': theGraphBalance,
   'the-graph-delegation': theGraphDelegation,
   'the-graph-indexing': theGraphIndexing,
+<<<<<<< HEAD
   whitelist
+=======
+  tokenlon
+>>>>>>> 00b716b (Add tokenlon strategy)
 };

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -102,9 +102,6 @@ export default {
   'the-graph-balance': theGraphBalance,
   'the-graph-delegation': theGraphDelegation,
   'the-graph-indexing': theGraphIndexing,
-<<<<<<< HEAD
-  whitelist
-=======
+  whitelist,
   tokenlon
->>>>>>> 00b716b (Add tokenlon strategy)
 };

--- a/src/strategies/tokenlon/examples.json
+++ b/src/strategies/tokenlon/examples.json
@@ -6,6 +6,8 @@
             "params": {
                 "uniswap": "0x7924a818013f39cf800f5589ff1f1f0def54f31f",
                 "sushiswap": "0x55d31f68975e446a40a2d02ffa4b0e1bfb233c2f",
+                "stakingRewardUniswap": "0x929CF614C917944dD278BC2134714EaA4121BC6A",
+                "stakingRewardSushiSwap": "0x11520d501E10E2E02A2715C4A9d3F8aEb1b72A7A",
                 "token": "0x0000000000095413afC295d19EDeb1Ad7B71c952",
                 "decimals": 18
             }

--- a/src/strategies/tokenlon/examples.json
+++ b/src/strategies/tokenlon/examples.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "Tokenlon",
+        "strategy": {
+            "name": "tokenlon",
+            "params": {
+                "uniswap": "0x7924a818013f39cf800f5589ff1f1f0def54f31f",
+                "sushiswap": "0x55d31f68975e446a40a2d02ffa4b0e1bfb233c2f",
+                "token": "0x0000000000095413afC295d19EDeb1Ad7B71c952",
+                "decimals": 18
+            }
+        },
+        "network": "1",
+        "addresses": [
+            "0x95bbf6bebb8caaa486ffab6faf76cf312a5abfd0",
+            "0x8f1D14f46a4a22DAA848E327FD7a30BfAE2D3d9c"
+        ],
+        "snapshot": 11905315
+    }
+]

--- a/src/strategies/tokenlon/index.ts
+++ b/src/strategies/tokenlon/index.ts
@@ -1,0 +1,117 @@
+import { formatUnits, parseUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'BenjaminLu';
+export const version = '0.1.0';
+
+const abi = [
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    [
+      [options.token, 'balanceOf', [options.uniswap]],
+      [options.uniswap, 'totalSupply'],
+      [options.token, 'balanceOf', [options.sushiswap]],
+      [options.sushiswap, 'totalSupply'],
+      ...addresses.map((address: any) => [
+        options.uniswap,
+        'balanceOf',
+        [address]
+      ]),
+      ...addresses.map((address: any) => [
+        options.sushiswap,
+        'balanceOf',
+        [address]
+      ]),
+      ...addresses.map((address: any) => [
+        options.token,
+        'balanceOf',
+        [address]
+      ])
+    ],
+    { blockTag }
+  );
+
+  const lonPerLPUniswap = parseUnits(response[0][0].toString(), 18).div(
+    response[1][0]
+  );
+  const lonPerLPSushiSwap = parseUnits(response[2][0].toString(), 18).div(
+    response[3][0]
+  );
+  const lpBalancesUniswap = response.slice(
+    4,
+    addresses.length + 4
+  );
+  const lpBalancesSushiSwap = response.slice(
+    addresses.length * 1 + 4,
+    addresses.length * 2 + 4
+  );
+  const tokenBalances = response.slice(
+    addresses.length * 2 + 4,
+    addresses.length * 3 + 4
+  );
+
+  return Object.fromEntries(
+    Array(addresses.length)
+      .fill('')
+      .map((_, i) => {
+        const lpBalanceUniswap = lpBalancesUniswap[i][0];
+        const lonLpBalanceUniswap = lpBalanceUniswap.mul(lonPerLPUniswap).div(parseUnits('1', 18));
+        const lpBalanceSushiSwap = lpBalancesSushiSwap[i][0];
+        const lonLpBalanceSushiSwap = lpBalanceSushiSwap.mul(lonPerLPSushiSwap).div(parseUnits('1', 18));
+
+        return [
+          addresses[i],
+          parseFloat(
+            formatUnits(
+              tokenBalances[i][0]
+                .add(lonLpBalanceUniswap)
+                .add(lonLpBalanceSushiSwap),
+              options.decimals
+            )
+          )
+        ];
+      })
+  );
+}


### PR DESCRIPTION
Add tokenlon stratrgy

LON phase 2 liquidity mining:
https://tokenlon.zendesk.com/hc/en-us/articles/360055773831-Tutorial-of-the-2nd-phase-of-LON-liquidity-mining

Relative contracts:
[Uniswap LON-ETH pair](https://etherscan.io/address/0x7924a818013f39cf800f5589ff1f1f0def54f31f#readContract)
[SushiSwap LON-USDT](https://etherscan.io/address/0x55d31f68975e446a40a2d02ffa4b0e1bfb233c2f#readContract)
[Uniswap StakingRewards contract](https://etherscan.io/address/0x929CF614C917944dD278BC2134714EaA4121BC6A#readContract)
[SushiSwap StakingMultiRewards contract](https://etherscan.io/address/0x11520d501E10E2E02A2715C4A9d3F8aEb1b72A7A#readContract)

Strategy:
```
user's voting power = LON balance of user +  
    (users' LP token + users' LP token staked in Uniswap StakingRewards contract) / LP total supply * LON balance of ETH-LON Uniswap pool +
    (earned in StakingRewards contract)
    (users' SLP token + users' SLP token staked in SushiSwap StakingMultiRewards contract) / SLP total supply * LON balance of LON-USDT SushiSwap pool +
    (earned in StakingMultiRewards contract)
```


```
npm run test --strategy=tokenlon
```

Result:
```
Strategy: "tokenlon"
Tokenlon
[
  {
    '0x95bbf6bebb8caaa486ffab6faf76cf312a5abfd0': 309.4628240485401,
    '0x8f1D14f46a4a22DAA848E327FD7a30BfAE2D3d9c': 251.76912211322397
  }
]
getScores: 1.782s
```